### PR TITLE
Fix typo in build.rs to fix builds with Rust 1.73+

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -62,5 +62,5 @@ fn main() {
             implementation.to_string()
         );
     }
-    println!("cargo::rustc-link-lib=crypto");
+    println!("cargo:rustc-link-lib=crypto");
 }


### PR DESCRIPTION
This PR fixes a typo in the build script that causes a build failure with Rust 1.73+:

```
Found a `cargo::key=value` build directive which is reserved for future use.
Either change the directive to `cargo:key=value` syntax (note the single `:`) or upgrade your version of Rust.
See https://doc.rust-lang.org/cargo/reference/build-scripts.html#outputs-of-the-build-script for more information about build script outputs.
```